### PR TITLE
init

### DIFF
--- a/npc/.gitignore
+++ b/npc/.gitignore
@@ -5,9 +5,11 @@
 !*.mk
 !*.[cSh]
 !*.v
+!*.sv
 !*.cc
 !*.cpp
 !.gitignore
 !README.md
 !ref/*
+!verible.filelist
 build/

--- a/npc/verible.filelist
+++ b/npc/verible.filelist
@@ -1,0 +1,6 @@
+./vsrc/frontend/frontend.sv
+./vsrc/include/build_config_pkg.sv
+./vsrc/include/config_pkg.sv
+./vsrc/include/global_config_pkg.sv
+./vsrc/include/test_config_pkg.sv
+./vsrc/triathlon.sv

--- a/npc/vsrc/frontend/frontend.sv
+++ b/npc/vsrc/frontend/frontend.sv
@@ -1,0 +1,4 @@
+module frontend #(
+    parameter config_pkg::cfg_t Cfg = config_pkg::EmptyCfg
+) ();
+endmodule : frontend

--- a/npc/vsrc/include/build_config_pkg.sv
+++ b/npc/vsrc/include/build_config_pkg.sv
@@ -1,0 +1,18 @@
+package build_config_pkg;
+
+  function automatic config_pkg::cfg_t build_config(config_pkg::user_cfg_t user_cfg);
+    // TODO
+    config_pkg::cfg_t cfg;
+    cfg.XLEN = user_cfg.XLEN;
+    cfg.VLEN = user_cfg.VLEN;
+    cfg.PLEN = user_cfg.VLEN;  // 假设物理地址大小等于虚拟地址大小
+    cfg.ICACHE_BYTE_SIZE = user_cfg.ICACHE_BYTE_SIZE;
+    cfg.ICACHE_SET_ASSOC = user_cfg.ICACHE_SET_ASSOC;
+    cfg.ICACHE_LINE_WIDTH = user_cfg.ICACHE_LINE_WIDTH;
+    cfg.ICACHE_SET_ASSOC_WIDTH = user_cfg.ICACHE_SET_ASSOC > 1 ? $clog2(user_cfg.ICACHE_SET_ASSOC) :
+        user_cfg.ICACHE_SET_ASSOC;
+    cfg.ICACHE_INDEX_WIDTH = $clog2(user_cfg.ICACHE_BYTE_SIZE / user_cfg.ICACHE_SET_ASSOC);
+    cfg.ICACHE_TAG_WIDTH = cfg.PLEN - cfg.ICACHE_INDEX_WIDTH;
+    return cfg;
+  endfunction
+endpackage

--- a/npc/vsrc/include/config_pkg.sv
+++ b/npc/vsrc/include/config_pkg.sv
@@ -1,0 +1,44 @@
+package config_pkg;
+
+  // ---------------
+  // Global Config
+  // ---------------
+  // Instruction Length
+  localparam int unsigned ILEN = 32;
+  // Number of RETired instructions per cycle
+  localparam int unsigned NRET = 4;
+
+
+  typedef struct packed {
+    // General Purpose Register Size (in bits)
+    int unsigned XLEN;
+    // Virtual address Size (in bits)
+    int unsigned VLEN;
+    // Instruction cache size (in bytes)
+    int unsigned ICACHE_BYTE_SIZE;
+    // Instruction cache associativity (number of ways)
+    int unsigned ICACHE_SET_ASSOC;
+    // Instruction cache line width
+    int unsigned ICACHE_LINE_WIDTH;
+  } user_cfg_t;
+
+  typedef struct packed {
+    // General Purpose Register Size (in bits)
+    int unsigned XLEN;
+    // Virtual address Size (in bits)
+    int unsigned VLEN;
+    // Physical address Size (in bits)
+    int unsigned PLEN;
+    // General Purpose Physical Register Size (in bits)
+    int unsigned GPLEN;
+
+    int unsigned FETCH_WIDTH;
+
+    int unsigned ICACHE_SET_ASSOC;
+    int unsigned ICACHE_SET_ASSOC_WIDTH;
+    int unsigned ICACHE_INDEX_WIDTH;
+    int unsigned ICACHE_TAG_WIDTH;
+    int unsigned ICACHE_LINE_WIDTH;
+  } cfg_t;
+  localparam cfg_t EmptyCfg = cfg_t'(0);
+endpackage

--- a/npc/vsrc/include/global_config_pkg.sv
+++ b/npc/vsrc/include/global_config_pkg.sv
@@ -1,0 +1,55 @@
+// Global types for Triathlon
+package global_config_pkg;
+
+  import test_config_pkg::*;
+  import config_pkg::*;
+
+  localparam config_pkg::cfg_t Cfg = config_pkg::build_config(test_config_pkg::TestCfg);
+
+
+
+  // For Example
+
+  // Exception information
+  typedef struct packed {
+    logic [Cfg.XLEN-1:0] cause;  // cause of exception
+    logic [Cfg.XLEN-1:0] tval;  // additional information of causing exception
+    logic [Cfg.GPLEN-1:0] tval2;  // additional info when a guest exception occurs
+    logic [31:0] tinst;  // transformed instruction information
+    logic gva;  // signals when a guest virtual address is written to tval
+    logic valid;
+  } exception_t;
+
+  // cache request ports
+  // I$ address translation responses
+  typedef struct packed {
+    logic                fetch_valid;      // address translation valid
+    logic [Cfg.PLEN-1:0] fetch_paddr;      // physical address in
+    exception_t          fetch_exception;  // exception occurred during fetch
+  } icache_arsp_t;
+
+  // I$ address translation requests
+  typedef struct packed {
+    logic                fetch_req;    // address translation request
+    logic [Cfg.VLEN-1:0] fetch_vaddr;  // virtual address out
+  } icache_areq_t;
+
+  // I$ data fetch requests
+  typedef struct packed {
+    logic                req;      // we request a new word
+    logic                kill_s1;  // kill the current request
+    logic                kill_s2;  // kill the last request
+    logic                spec;     // request is speculative
+    logic [Cfg.VLEN-1:0] vaddr;    // 1st cycle: index is taken for lookup
+  } icache_dreq_t;
+
+  // I$ data fetch responses
+  typedef struct packed {
+    logic                       ready;  // icache is ready
+    logic                       valid;  // signals a valid read
+    logic [Cfg.FETCH_WIDTH-1:0] data;   // 2+ cycle out: tag
+    logic [Cfg.VLEN-1:0]        vaddr;  // virtual address out
+    exception_t                 ex;     // we've encountered an exception
+  } icache_drsp_t;
+
+endpackage : global_config_pkg

--- a/npc/vsrc/include/test_config_pkg.sv
+++ b/npc/vsrc/include/test_config_pkg.sv
@@ -1,0 +1,13 @@
+import config_pkg::*;
+
+package test_config_pkg;
+
+  localparam config_pkg::user_cfg_t TestCfg = '{
+      XLEN          : unsigned'(32),
+      VLEN          : unsigned'(64),
+      ICACHE_BYTE_SIZE : unsigned'(4096),
+      ICACHE_SET_ASSOC : unsigned'(4),
+      ICACHE_LINE_WIDTH : unsigned'(32)
+  };
+
+endpackage : test_config_pkg

--- a/npc/vsrc/triathlon.sv
+++ b/npc/vsrc/triathlon.sv
@@ -1,0 +1,22 @@
+import global_config_pkg::*;
+
+module triathlon #(
+    // Config
+    parameter config_pkg::cfg_t Cfg = global_config_pkg::Cfg
+) (
+    // Subsystem Clock
+    input logic clk_i,
+    // Asynchronous reset active low
+    input logic rst_ni
+);
+
+  // --------------
+  // Frontend
+  // --------------
+  frontend #(
+      .Cfg(Cfg)
+  ) i_frontend (
+      .clk_i (clk_i),
+      .rst_ni(rst_ni)
+  );
+endmodule : triathlon


### PR DESCRIPTION
## Sourcery 总结

初始化 NPC 仓库，包含用于配置、全局类型以及顶层 triathlon 和 frontend 模块的核心包。

新功能：
- 添加 `config_pkg` 包，定义 `user_cfg_t` 和 `cfg_t` 配置类型及常量
- 实现 `build_config_pkg` 函数，从 `user_cfg_t` 生成 `cfg_t`
- 提供 `test_config_pkg`，带有默认的 `TestCfg` 参数
- 引入 `global_config_pkg`，定义 `exception_t` 和 `icache` 接口结构
- 添加参数化的 `triathlon` 顶层模块，实例化 `frontend`
- 创建一个由 `cfg` 参数化的存根 `frontend` 模块

杂项：
- 将 `.gitignore` 和 `verible.filelist` 添加到仓库中

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Initialize the NPC repository with core packages for configuration, global types, and the top-level triathlon and frontend modules

New Features:
- Add config_pkg package defining user_cfg_t and cfg_t configuration types and constants
- Implement build_config_pkg function to generate cfg_t from user_cfg_t
- Provide test_config_pkg with default TestCfg parameters
- Introduce global_config_pkg defining exception_t and icache interface structures
- Add parameterized triathlon top-level module instantiating the frontend
- Create a stub frontend module parameterized by cfg

Chores:
- Add .gitignore and verible.filelist to the repository

</details>