### PR TITLE
issue

### DIFF
--- a/npc/csrc/test_bpu.cpp
+++ b/npc/csrc/test_bpu.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
   std::cout << "Checking PLEN..." << std::endl;
   top->pc_i = 0x80000000;
   tick(top, 1);
-  assert(top->npc_o == 0x80000000 + 128);
+  assert(top->npc_o == 0x80000000 + 16);
   std::cout << "--- [PASSED] All checks passed successfully! ---" << std::endl;
   delete top;
   return 0;

--- a/npc/csrc/test_issue.cpp
+++ b/npc/csrc/test_issue.cpp
@@ -40,7 +40,7 @@ struct DispatchInstr {
 void set_dispatch(Vtb_issue *top, const std::vector<DispatchInstr>& instrs) {
     // 先清零
     top->dispatch_valid = 0;
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < INSTR_PER_FETCH; ++i) {
         top->dispatch_op[i] = 0;
         top->dispatch_dst[i] = 0;
         top->dispatch_v1[i] = 0;

--- a/npc/csrc/test_issue.cpp
+++ b/npc/csrc/test_issue.cpp
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
     // 我们给一点时间让它们发射
     for(int i=0; i<3; ++i) {
         if (top->alu0_en) {
-            std::cout << "  [Cycle " << i << "] ALU0 Fire! Op=0x" << std::hex << top->alu0_op << std::endl;
+            std::cout << "  [Cycle " << i << "] ALU0 Fire! Op=0x" << std::hex << top->alu0_op << std::dec << std::endl;
             if (top->alu0_op == OP_ADD) executed_0 = true;
             if (top->alu0_op == OP_SUB) executed_1 = true;
         }

--- a/npc/csrc/test_issue.cpp
+++ b/npc/csrc/test_issue.cpp
@@ -1,0 +1,306 @@
+// csrc/test_issue.cpp
+#include "Vtb_issue.h"
+#include "verilated.h"
+#include <cassert>
+#include <iostream>
+#include <vector>
+#include <iomanip>
+
+// =================================================================
+// 配置参数
+// =================================================================
+const int RS_DEPTH = 16;
+const int INSTR_PER_FETCH = 4;
+
+vluint64_t main_time = 0;
+
+void tick(Vtb_issue *top) {
+    top->clk = 0;
+    top->eval();
+    main_time++;
+    top->clk = 1;
+    top->eval();
+    main_time++;
+}
+
+// 辅助结构：用于定义一条要 Dispatch 的指令
+struct DispatchInstr {
+    bool valid;
+    uint32_t op;
+    uint32_t dst_tag;
+    uint32_t v1;
+    uint32_t q1;
+    bool r1;
+    uint32_t v2;
+    uint32_t q2;
+    bool r2;
+};
+
+// 辅助函数：设置 Dispatch 输入端口
+void set_dispatch(Vtb_issue *top, const std::vector<DispatchInstr>& instrs) {
+    // 先清零
+    top->dispatch_valid = 0;
+    for (int i = 0; i < 4; ++i) {
+        top->dispatch_op[i] = 0;
+        top->dispatch_dst[i] = 0;
+        top->dispatch_v1[i] = 0;
+        top->dispatch_q1[i] = 0;
+        top->dispatch_r1[i] = 0;
+        top->dispatch_v2[i] = 0;
+        top->dispatch_q2[i] = 0;
+        top->dispatch_r2[i] = 0;
+    }
+
+    // 设置有效值
+    uint8_t valid_mask = 0;
+    for (size_t i = 0; i < instrs.size() && i < 4; ++i) {
+        if (instrs[i].valid) {
+            valid_mask |= (1 << i);
+            top->dispatch_op[i]  = instrs[i].op;
+            top->dispatch_dst[i] = instrs[i].dst_tag;
+            top->dispatch_v1[i]  = instrs[i].v1;
+            top->dispatch_q1[i]  = instrs[i].q1;
+            top->dispatch_r1[i]  = instrs[i].r1;
+            top->dispatch_v2[i]  = instrs[i].v2;
+            top->dispatch_q2[i]  = instrs[i].q2;
+            top->dispatch_r2[i]  = instrs[i].r2;
+        }
+    }
+    top->dispatch_valid = valid_mask;
+}
+
+// 辅助函数：设置 CDB 广播
+void set_cdb(Vtb_issue *top, const std::vector<std::pair<uint32_t, uint32_t>>& updates) {
+    top->cdb_valid = 0;
+    for(int i=0; i<4; ++i) {
+        top->cdb_tag[i] = 0;
+        top->cdb_val[i] = 0;
+    }
+
+    uint8_t valid_mask = 0;
+    for (size_t i = 0; i < updates.size() && i < 4; ++i) {
+        valid_mask |= (1 << i);
+        top->cdb_tag[i] = updates[i].first;  // Tag
+        top->cdb_val[i] = updates[i].second; // Value
+    }
+    top->cdb_valid = valid_mask;
+}
+
+int main(int argc, char **argv) {
+    Verilated::commandArgs(argc, argv);
+    Vtb_issue *top = new Vtb_issue;
+
+    std::cout << "--- [START] Issue Stage Verification ---" << std::endl;
+
+    // 1. 复位
+    top->rst_n = 0;
+    top->clk = 0;
+    set_dispatch(top, {});
+    set_cdb(top, {});
+    tick(top);
+    top->rst_n = 1;
+    tick(top); // 等待复位释放
+
+    std::cout << "[" << main_time << "] Reset complete. issue_ready = " << (int)top->issue_ready << std::endl;
+    assert(top->issue_ready == 1 && "Should be ready after reset");
+
+    // =================================================================
+    // Test 1: 发射 2 条已就绪的指令 (Direct Issue)
+    // =================================================================
+    std::cout << "\n--- Test 1: Dispatch Ready Instructions ---" << std::endl;
+    
+    // 使用合法的十六进制数
+    // 0xADD00001 (ADD) -> OK
+    // 0x50B00002 (SUB) -> OK (50B looks like SOB/SUB)
+    uint32_t OP_ADD = 0xADD00001;
+    uint32_t OP_SUB = 0x50B00002;
+
+    std::vector<DispatchInstr> group1 = {
+        {true, OP_ADD, 3, 100, 0, 1, 200, 0, 1}, // Op, DstTag, V1, Q1, R1, V2, Q2, R2
+        {true, OP_SUB, 6, 300, 0, 1, 400, 0, 1}
+    };
+    set_dispatch(top, group1);
+    
+    // Tick 1: Dispatch Write -> RS Busy 变高
+    tick(top); 
+    
+    // 撤销 Dispatch 请求
+    set_dispatch(top, {});
+
+    // 检查是否发射
+    top->eval(); 
+    
+    bool executed_0 = false;
+    bool executed_1 = false;
+
+    // 我们给一点时间让它们发射
+    for(int i=0; i<3; ++i) {
+        if (top->alu0_en) {
+            std::cout << "  [Cycle " << i << "] ALU0 Fire! Op=0x" << std::hex << top->alu0_op << std::endl;
+            if (top->alu0_op == OP_ADD) executed_0 = true;
+            if (top->alu0_op == OP_SUB) executed_1 = true;
+        }
+        if (top->alu1_en) {
+            std::cout << "  [Cycle " << i << "] ALU1 Fire! Op=0x" << std::hex << top->alu1_op << std::endl;
+            if (top->alu1_op == OP_ADD) executed_0 = true;
+            if (top->alu1_op == OP_SUB) executed_1 = true;
+        }
+        tick(top);
+    }
+
+    assert(executed_0 && "Instr 0 failed to issue");
+    assert(executed_1 && "Instr 1 failed to issue");
+    std::cout << "--- Test 1 PASSED ---" << std::endl;
+
+
+    // =================================================================
+    // Test 2: 依赖等待测试 (Wait for CDB)
+    // =================================================================
+    std::cout << "\n--- Test 2: Dependency & CDB Wakeup ---" << std::endl;
+
+    // 使用合法的十六进制数
+    uint32_t OP_WAIT_A = 0x000000AA; // WAIT A
+    uint32_t OP_WAIT_B = 0x000000BB; // WAIT B
+    uint32_t DATA_10   = 0xDA7A0010; // DATA 10
+    uint32_t DATA_11   = 0xDA7A0011; // DATA 11
+
+    // 发射 2 条未就绪指令
+    // Instr A: 依赖 Tag 10 (Q1=10, R1=0)
+    // Instr B: 依赖 Tag 11 (Q2=11, R2=0)
+    std::vector<DispatchInstr> group2 = {
+        {true, OP_WAIT_A, 20, 0, 10, 0, 500, 0, 1}, // Src1 not ready (Wait Tag 10)
+        {true, OP_WAIT_B, 21, 600, 0, 1, 0, 11, 0}  // Src2 not ready (Wait Tag 11)
+    };
+    set_dispatch(top, group2);
+    tick(top);
+    set_dispatch(top, {}); // Stop dispatch
+
+    // 运行几个周期，确保它们没有提前发射
+    for(int i=0; i<3; ++i) {
+        top->eval();
+        if (top->alu0_en || top->alu1_en) {
+            std::cout << "[ERROR] Instruction issued before operands were ready!" << std::endl;
+            assert(false);
+        }
+        tick(top);
+    }
+    std::cout << "  [Verified] Instructions held in RS waiting for operands." << std::endl;
+
+    // 模拟 CDB 广播 Tag 10 和 11
+    std::cout << "  [Action] Broadcasting CDB Tag 10 and 11..." << std::endl;
+    std::vector<std::pair<uint32_t, uint32_t>> cdb_data = {
+        {10, DATA_10}, 
+        {11, DATA_11}
+    };
+    set_cdb(top, cdb_data);
+    
+    // CDB 写入是同步的，需要一个 Tick
+    tick(top); 
+    set_cdb(top, {}); // Clear CDB
+
+    // 现在指令应该已经捕获数据并 Ready 了，Select 逻辑应该选中它们
+    bool fired_a = false;
+    bool fired_b = false;
+
+    for(int i=0; i<5; ++i) {
+        top->eval();
+        if (top->alu0_en) {
+            if (top->alu0_op == OP_WAIT_A) {
+                std::cout << "  ALU0 Issued Instr A. V1=" << std::hex << top->alu0_v1 << " (Expect " << DATA_10 << ")" << std::endl;
+                assert(top->alu0_v1 == DATA_10); // 验证 Forwarding 结果
+                fired_a = true;
+            }
+            if (top->alu0_op == OP_WAIT_B) {
+                std::cout << "  ALU0 Issued Instr B. V2=" << std::hex << top->alu0_v2 << " (Expect " << DATA_11 << ")" << std::endl;
+                assert(top->alu0_v2 == DATA_11);
+                fired_b = true;
+            }
+        }
+        if (top->alu1_en) {
+             if (top->alu1_op == OP_WAIT_A) {
+                std::cout << "  ALU1 Issued Instr A. V1=" << std::hex << top->alu1_v1 << std::endl;
+                assert(top->alu1_v1 == DATA_10);
+                fired_a = true;
+            }
+            if (top->alu1_op == OP_WAIT_B) {
+                std::cout << "  ALU1 Issued Instr B. V2=" << std::hex << top->alu1_v2 << std::endl;
+                assert(top->alu1_v2 == DATA_11);
+                fired_b = true;
+            }
+        }
+        tick(top);
+    }
+
+    assert(fired_a && fired_b && "Dependent instructions failed to issue after CDB wakeup");
+    std::cout << "--- Test 2 PASSED ---" << std::endl;
+
+    // =================================================================
+    // Test 3: RS 满状态与阻塞 (Full Stall)
+    // =================================================================
+    std::cout << "\n--- Test 3: RS Full Stall Check ---" << std::endl;
+    // 目前 RS 应该是空的。RS_DEPTH = 16.
+    // 我们连续填入 16 条 "卡住" 的指令 (依赖一个永不到来的 Tag 99)
+    
+    uint32_t OP_STALL = 0x57A11000; // STALL
+    DispatchInstr stall_instr = {true, OP_STALL, 99, 0, 99, 0, 0, 99, 0};
+    std::vector<DispatchInstr> batch(4, stall_instr); // 每次发 4 条
+
+    // 发射 4 次，共 16 条
+    for(int i=0; i<4; ++i) {
+        std::cout << "  Filling Batch " << i+1 << " (Ready=" << (int)top->issue_ready << ")" << std::endl;
+        assert(top->issue_ready == 1); // 此时应该还没满
+        set_dispatch(top, batch);
+        tick(top);
+    }
+    set_dispatch(top, {});
+    
+    // 此时 16 条槽位应该全满
+    top->eval();
+    std::cout << "  [Check] RS Full. issue_ready = " << (int)top->issue_ready << std::endl;
+    assert(top->issue_ready == 0); // 必须为 0
+
+    // 尝试在满的时候强行发射 (应该被忽略)
+    std::cout << "  [Action] Attempting dispatch when FULL..." << std::endl;
+    
+    uint32_t OP_NEW = 0x000000FF; // NEW
+    DispatchInstr new_instr = {true, OP_NEW, 50, 0, 0, 1, 0, 0, 1}; // 这是一条 Ready 指令
+    set_dispatch(top, {new_instr, new_instr, new_instr, new_instr});
+    tick(top);
+    set_dispatch(top, {}); // Stop
+
+    // 检查是否偷跑进去了
+    // 如果进了，由于它是 Ready 的，它应该会马上发射。如果不发射，说明没进去。
+    for(int i=0; i<3; ++i) {
+        if (top->alu0_en && top->alu0_op == OP_NEW) assert(false && "Dispatch accepted while RS FULL!");
+        if (top->alu1_en && top->alu1_op == OP_NEW) assert(false && "Dispatch accepted while RS FULL!");
+        tick(top);
+    }
+    std::cout << "  [Verified] No instructions accepted while FULL." << std::endl;
+
+    // 释放一些空间 (通过 CDB 唤醒刚才填进去的指令)
+    std::cout << "  [Action] Releasing instructions via CDB Tag 99..." << std::endl;
+    set_cdb(top, {{99, 0xDEADBEEF}});
+    tick(top);
+    set_cdb(top, {});
+
+    // 等待它们发射并离开 RS
+    int fired_count = 0;
+    for(int i=0; i<20; ++i) {
+        if (top->alu0_en) fired_count++;
+        if (top->alu1_en) fired_count++;
+        tick(top);
+    }
+    std::cout << "  [Info] Fired " << fired_count << " instructions after release." << std::endl;
+    
+    // 此时 RS 应该有空位了，issue_ready 应该恢复
+    top->eval();
+    std::cout << "  [Check] issue_ready = " << (int)top->issue_ready << std::endl;
+    assert(top->issue_ready == 1);
+
+    std::cout << "--- Test 3 PASSED ---" << std::endl;
+
+    std::cout << "\n--- [SUCCESS] All Issue Stage Tests Passed! ---" << std::endl;
+
+    delete top;
+    return 0;
+}

--- a/npc/vsrc/backend/issue/issue.sv
+++ b/npc/vsrc/backend/issue/issue.sv
@@ -1,0 +1,190 @@
+module issue #(
+    parameter config_pkg::cfg_t Cfg = config_pkg::EmptyCfg,
+    parameter RS_DEPTH = Cfg.RS_DEPTH,
+    parameter DATA_W   = Cfg.ILEN,
+    parameter TAG_W    = 6
+)(
+    input wire clk,
+    input wire rst_n,
+
+    input wire [3:0]        dispatch_valid,
+    input wire [31:0]       dispatch_op     [0:3],
+    input wire [TAG_W-1:0]  dispatch_dst    [0:3],
+    // Src1
+    input wire [DATA_W-1:0] dispatch_v1     [0:3],
+    input wire [TAG_W-1:0]  dispatch_q1     [0:3],
+    input wire              dispatch_r1     [0:3],
+    // Src2
+    input wire [DATA_W-1:0] dispatch_v2     [0:3],
+    input wire [TAG_W-1:0]  dispatch_q2     [0:3],
+    input wire              dispatch_r2     [0:3],
+
+    output wire             issue_ready,   // 给流水线前端：RS满了，停！
+    
+    // 来自 CDB 的广播 (给 RS 监听用)
+    input wire [3:0]        cdb_valid,
+    input wire [TAG_W-1:0]  cdb_tag   [0:3],
+    input wire [DATA_W-1:0] cdb_val   [0:3],
+
+    // ALU 0 接口
+    output wire             alu0_en,
+    output wire [31:0]      alu0_op,
+    output wire [DATA_W-1:0] alu0_v1,
+    output wire [DATA_W-1:0] alu0_v2,
+    output wire [TAG_W-1:0]  alu0_dst,
+    
+    // ALU 1 接口
+    output wire             alu1_en,
+    output wire [31:0]      alu1_op,
+    output wire [DATA_W-1:0] alu1_v1,
+    output wire [DATA_W-1:0] alu1_v2,
+    output wire [TAG_W-1:0]  alu1_dst
+);
+    wire full_stall; 
+    assign issue_ready = ~full_stall;
+    // A. Allocator <-> RS 之间的控制线
+    wire [RS_DEPTH-1:0]      rs_busy_wires;      // RS -> Alloc
+    wire [RS_DEPTH-1:0]      alloc_wen;          // Alloc -> RS (写使能)
+    wire [$clog2(RS_DEPTH)-1:0] routing_idx [0:3]; // Alloc -> Crossbar (路由地址)
+
+    // B. RS <-> Select Logic 之间的握手线
+    wire [RS_DEPTH-1:0]      rs_ready_wires;     // RS -> Select
+    wire [RS_DEPTH-1:0]      grant_mask_wires;   // Select -> RS (清除Busy)
+
+    // C. Select Logic -> ALU Mux 的选择信号
+    wire [$clog2(RS_DEPTH)-1:0] alu0_sel;
+    wire [$clog2(RS_DEPTH)-1:0] alu1_sel;
+
+    // D. Crossbar <-> RS 输入数据线 (16组宽总线)
+    // 这些是在 always_comb 里被驱动的
+    logic [31:0]       rs_in_op  [0:RS_DEPTH-1];
+    logic [TAG_W-1:0]  rs_in_dst [0:RS_DEPTH-1];
+    logic [DATA_W-1:0] rs_in_v1  [0:RS_DEPTH-1];
+    logic [TAG_W-1:0]  rs_in_q1  [0:RS_DEPTH-1];
+    logic              rs_in_r1  [0:RS_DEPTH-1];
+    logic [DATA_W-1:0] rs_in_v2  [0:RS_DEPTH-1];
+    logic [TAG_W-1:0]  rs_in_q2  [0:RS_DEPTH-1];
+    logic              rs_in_r2  [0:RS_DEPTH-1];
+
+    // ==========================================
+    // 模块 1: 分配器 (Allocator)
+    // ==========================================
+    rs_allocator #(
+        .Cfg(Cfg)
+    ) u_alloc (
+        .rs_busy     ( rs_busy_wires ),
+        .instr_valid ( dispatch_valid ),
+        .entry_wen   ( alloc_wen ),
+        .idx_map     ( routing_idx ),
+        .full_stall  ( full_stall )
+    );
+    
+    always_comb begin
+        for (int k = 0; k < RS_DEPTH; k++) begin
+            rs_in_op[k]  = 0; rs_in_dst[k] = 0;
+            rs_in_v1[k]  = 0; rs_in_q1[k]  = 0; rs_in_r1[k] = 0;
+            rs_in_v2[k]  = 0; rs_in_q2[k]  = 0; rs_in_r2[k] = 0;
+        end
+
+        if (dispatch_valid[0]) begin
+            rs_in_op [ routing_idx[0] ] = dispatch_op[0];
+            rs_in_dst[ routing_idx[0] ] = dispatch_dst[0];
+            rs_in_v1 [ routing_idx[0] ] = dispatch_v1[0];
+            rs_in_q1 [ routing_idx[0] ] = dispatch_q1[0];
+            rs_in_r1 [ routing_idx[0] ] = dispatch_r1[0];
+            rs_in_v2 [ routing_idx[0] ] = dispatch_v2[0];
+            rs_in_q2 [ routing_idx[0] ] = dispatch_q2[0];
+            rs_in_r2 [ routing_idx[0] ] = dispatch_r2[0];
+        end
+        
+        // 指令 1
+        if (dispatch_valid[1]) begin
+            rs_in_op [ routing_idx[1] ] = dispatch_op[1];
+            rs_in_dst[ routing_idx[1] ] = dispatch_dst[1];
+            rs_in_v1 [ routing_idx[1] ] = dispatch_v1[1];
+            rs_in_q1 [ routing_idx[1] ] = dispatch_q1[1];
+            rs_in_r1 [ routing_idx[1] ] = dispatch_r1[1];
+            rs_in_v2 [ routing_idx[1] ] = dispatch_v2[1];
+            rs_in_q2 [ routing_idx[1] ] = dispatch_q2[1];
+            rs_in_r2 [ routing_idx[1] ] = dispatch_r2[1];
+        end
+
+        if (dispatch_valid[2]) begin
+            rs_in_op [ routing_idx[2] ] = dispatch_op[2];
+            rs_in_dst[ routing_idx[2] ] = dispatch_dst[2];
+            rs_in_v1 [ routing_idx[2] ] = dispatch_v1[2];
+            rs_in_q1 [ routing_idx[2] ] = dispatch_q1[2];
+            rs_in_r1 [ routing_idx[2] ] = dispatch_r1[2];
+            rs_in_v2 [ routing_idx[2] ] = dispatch_v2[2];
+            rs_in_q2 [ routing_idx[2] ] = dispatch_q2[2];
+            rs_in_r2 [ routing_idx[2] ] = dispatch_r2[2];
+        end
+
+        if (dispatch_valid[3]) begin
+            rs_in_q1 [ routing_idx[3] ] = dispatch_q1[3];
+            rs_in_r1 [ routing_idx[3] ] = dispatch_r1[3];
+            rs_in_v2 [ routing_idx[3] ] = dispatch_v2[3];
+            rs_in_q2 [ routing_idx[3] ] = dispatch_q2[3];
+            rs_in_r2 [ routing_idx[3] ] = dispatch_r2[3];
+            rs_in_op [ routing_idx[3] ] = dispatch_op[3];
+            rs_in_dst[ routing_idx[3] ] = dispatch_dst[3];
+            rs_in_v1 [ routing_idx[3] ] = dispatch_v1[3];
+        end
+    end
+
+    reservation_station #(
+        .Cfg(Cfg)
+    ) u_rs (
+        .clk         ( clk ),
+        .rst_n       ( rst_n ),
+        
+        // 写端口 (连接 Crossbar 的结果)
+        .entry_wen   ( alloc_wen ),
+        .in_op       ( rs_in_op ),
+        .in_dst_tag  ( rs_in_dst ),
+        .in_v1       ( rs_in_v1 ), .in_q1(rs_in_q1), .in_r1(rs_in_r1),
+        .in_v2       ( rs_in_v2 ), .in_q2(rs_in_q2), .in_r2(rs_in_r2),
+
+        // CDB 监听端口
+        .cdb_valid   ( cdb_valid ),
+        .cdb_tag     ( cdb_tag ),
+        .cdb_value   ( cdb_val ),
+
+        .busy_vector ( rs_busy_wires ),
+
+        // 状态输出
+        .ready_mask  ( rs_ready_wires ),
+        .issue_grant ( grant_mask_wires ),
+        
+        .sel_idx_0   ( alu0_sel ),
+        .out_op_0    ( alu0_op ),
+        .out_v1_0    ( alu0_v1 ),
+        .out_v2_0    ( alu0_v2 ),
+        .out_dst_tag_0 ( alu0_dst ),
+
+        .sel_idx_1   ( alu1_sel ),
+        .out_op_1    ( alu1_op ),
+        .out_v1_1    ( alu1_v1 ),
+        .out_v2_1    ( alu1_v2 ),
+        .out_dst_tag_1 ( alu1_dst )
+    );
+
+    // ==========================================
+    // 模块 3: 选择逻辑 (Select Logic)
+    // ==========================================
+    select_logic #(
+        .Cfg(Cfg)
+    ) u_select (
+        .ready_mask       ( rs_ready_wires ),   
+        .issue_grant_mask ( grant_mask_wires ),
+        
+        // 控制 ALU 0
+        .alu0_valid       ( alu0_en ),
+        .alu0_rs_idx      ( alu0_sel ),
+        
+        // 控制 ALU 1
+        .alu1_valid       ( alu1_en ),
+        .alu1_rs_idx      ( alu1_sel )
+    );
+
+endmodule

--- a/npc/vsrc/backend/issue/rs.sv
+++ b/npc/vsrc/backend/issue/rs.sv
@@ -1,0 +1,147 @@
+module reservation_station #(
+    parameter config_pkg::cfg_t Cfg = config_pkg::EmptyCfg,
+    parameter RS_DEPTH  = Cfg.RS_DEPTH,
+    parameter DATA_W    = Cfg.ILEN,
+    parameter RS_IDX_W  = $clog2(Cfg.RS_DEPTH),
+    parameter TAG_W     = 6,
+    parameter CDB_W     = 4
+)(
+    input wire clk,
+    input wire rst_n,
+
+    input wire [RS_DEPTH-1:0]   entry_wen,
+    
+    // 写端口 (来自 Crossbar)
+    input wire [31:0]           in_op       [0:RS_DEPTH-1],
+    input wire [TAG_W-1:0]      in_dst_tag  [0:RS_DEPTH-1],
+    input wire [DATA_W-1:0]     in_v1       [0:RS_DEPTH-1],
+    input wire [TAG_W-1:0]      in_q1       [0:RS_DEPTH-1],
+    input wire                  in_r1       [0:RS_DEPTH-1],
+    input wire [DATA_W-1:0]     in_v2       [0:RS_DEPTH-1],
+    input wire [TAG_W-1:0]      in_q2       [0:RS_DEPTH-1],
+    input wire                  in_r2       [0:RS_DEPTH-1],
+
+    // CDB 监听
+    input wire [CDB_W-1:0]      cdb_valid,
+    input wire [TAG_W-1:0]      cdb_tag     [0:CDB_W-1],
+    input wire [DATA_W-1:0]     cdb_value   [0:CDB_W-1],
+
+    // 握手信号
+    output wire [RS_DEPTH-1:0]  ready_mask, 
+    input wire [RS_DEPTH-1:0]   issue_grant,
+
+    output wire [RS_DEPTH-1:0]  busy_vector,
+
+    // ALU 0 读取通道
+    input wire [RS_IDX_W-1:0]   sel_idx_0,    // 新增：输入索引
+    output logic [31:0]         out_op_0,     // 修改：带后缀
+    output logic [TAG_W-1:0]    out_dst_tag_0,
+    output logic [DATA_W-1:0]   out_v1_0,
+    output logic [DATA_W-1:0]   out_v2_0,
+
+    // ALU 1 读取通道
+    input wire [RS_IDX_W-1:0]   sel_idx_1,    // 新增：输入索引
+    output logic [31:0]         out_op_1,
+    output logic [TAG_W-1:0]    out_dst_tag_1,
+    output logic [DATA_W-1:0]   out_v1_1,
+    output logic [DATA_W-1:0]   out_v2_1
+);
+
+    // RS 存储阵列
+    reg [RS_DEPTH-1:0]  busy;
+    reg [31:0]          op_arr  [0:RS_DEPTH-1];
+    reg [TAG_W-1:0]     dst_arr [0:RS_DEPTH-1];
+    
+    reg [DATA_W-1:0]    v1_arr  [0:RS_DEPTH-1];
+    reg [TAG_W-1:0]     q1_arr  [0:RS_DEPTH-1];
+    reg                 r1_arr  [0:RS_DEPTH-1];
+    
+    reg [DATA_W-1:0]    v2_arr  [0:RS_DEPTH-1];
+    reg [TAG_W-1:0]     q2_arr  [0:RS_DEPTH-1];
+    reg                 r2_arr  [0:RS_DEPTH-1];
+
+    integer i, k;
+
+    // 写入与 CDB 监听逻辑 (保持不变)
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            busy <= {RS_DEPTH{1'b0}};
+        end else begin
+            for (i = 0; i < RS_DEPTH; i = i + 1) begin
+                if (issue_grant[i]) begin
+                    busy[i] <= 1'b0;
+                end
+                // 写逻辑 (保持原样...)
+                else if (entry_wen[i]) begin
+                    busy[i]     <= 1'b1;
+                    op_arr[i]   <= in_op[i];
+                    dst_arr[i]  <= in_dst_tag[i];
+                    
+                    v1_arr[i] <= in_v1[i];
+                    q1_arr[i] <= in_q1[i];
+                    r1_arr[i] <= in_r1[i];
+                    // Forwarding Check Src1
+                    if (!in_r1[i]) begin
+                        for (k = 0; k < CDB_W; k = k + 1) begin
+                            if (cdb_valid[k] && (cdb_tag[k] == in_q1[i])) begin
+                                v1_arr[i] <= cdb_value[k];
+                                r1_arr[i] <= 1'b1;
+                            end
+                        end
+                    end
+
+                    v2_arr[i] <= in_v2[i];
+                    q2_arr[i] <= in_q2[i];
+                    r2_arr[i] <= in_r2[i];
+                    // Forwarding Check Src2
+                    if (!in_r2[i]) begin
+                        for (k = 0; k < CDB_W; k = k + 1) begin
+                            if (cdb_valid[k] && (cdb_tag[k] == in_q2[i])) begin
+                                v2_arr[i] <= cdb_value[k];
+                                r2_arr[i] <= 1'b1;
+                            end
+                        end
+                    end
+                end
+                // 监听逻辑
+                else if (busy[i]) begin
+                    for (k = 0; k < CDB_W; k = k + 1) begin
+                        if (cdb_valid[k]) begin
+                            if (!r1_arr[i] && (q1_arr[i] == cdb_tag[k])) begin
+                                v1_arr[i] <= cdb_value[k];
+                                r1_arr[i] <= 1'b1;
+                            end
+                            if (!r2_arr[i] && (q2_arr[i] == cdb_tag[k])) begin
+                                v2_arr[i] <= cdb_value[k];
+                                r2_arr[i] <= 1'b1;
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    genvar g;
+    generate
+        for (g = 0; g < RS_DEPTH; g = g + 1) begin : gen_ready
+            assign ready_mask[g] = busy[g] && r1_arr[g] && r2_arr[g];
+        end
+    endgenerate
+
+    
+    // Port 0 (给 ALU 0)
+    assign out_op_0      = op_arr[sel_idx_0];
+    assign out_dst_tag_0 = dst_arr[sel_idx_0];
+    assign out_v1_0      = v1_arr[sel_idx_0];
+    assign out_v2_0      = v2_arr[sel_idx_0];
+
+    // Port 1 (给 ALU 1)
+    assign out_op_1      = op_arr[sel_idx_1];
+    assign out_dst_tag_1 = dst_arr[sel_idx_1];
+    assign out_v1_1      = v1_arr[sel_idx_1];
+    assign out_v2_1      = v2_arr[sel_idx_1];
+
+    assign busy_vector = busy;
+
+endmodule

--- a/npc/vsrc/backend/issue/rs_allocator.sv
+++ b/npc/vsrc/backend/issue/rs_allocator.sv
@@ -1,0 +1,63 @@
+module rs_allocator #(
+    parameter config_pkg::cfg_t Cfg = config_pkg::EmptyCfg,
+    parameter RS_DEPTH = Cfg.RS_DEPTH
+)(
+    input wire [RS_DEPTH-1:0] rs_busy,
+    input wire [3:0]          instr_valid,
+    output logic [RS_DEPTH-1:0] entry_wen, 
+    output logic [$clog2(RS_DEPTH)-1:0] idx_map [0:3],
+    output logic full_stall
+);
+
+    integer i;
+    logic [2:0] found_count;
+    logic [2:0] needed_count;
+    always_comb begin
+        entry_wen = 0;
+        idx_map[0] = 0; idx_map[1] = 0; idx_map[2] = 0; idx_map[3] = 0;
+        found_count = 0;
+        full_stall = 0;
+
+        for (i = 0; i < RS_DEPTH; i = i + 1) begin
+            if (!rs_busy[i]) begin
+                
+                case (found_count)
+                    0: begin 
+                        if (instr_valid[0]) begin
+                            entry_wen[i] = 1'b1;
+                            idx_map[0]   = i;
+                        end
+                    end
+                    1: begin 
+                        if (instr_valid[1]) begin
+                            entry_wen[i] = 1'b1;
+                            idx_map[1]   = i;
+                        end
+                    end
+                    2: begin 
+                        if (instr_valid[2]) begin
+                            entry_wen[i] = 1'b1;
+                            idx_map[2]   = i;
+                        end
+                    end
+                    3: begin 
+                        if (instr_valid[3]) begin
+                            entry_wen[i] = 1'b1;
+                            idx_map[3]   = i;
+                        end
+                    end
+                endcase
+                
+                if (found_count < 4) begin
+                    found_count = found_count + 1;
+                end
+            end
+        end
+        needed_count = instr_valid[0] + instr_valid[1] + instr_valid[2] + instr_valid[3];
+        if (found_count < needed_count || found_count == 0) begin
+            full_stall = 1'b1;
+            entry_wen  = 0;
+        end
+    end
+
+endmodule

--- a/npc/vsrc/backend/issue/select.sv
+++ b/npc/vsrc/backend/issue/select.sv
@@ -1,0 +1,67 @@
+module select_logic #(
+    parameter config_pkg::cfg_t Cfg = config_pkg::EmptyCfg,
+    parameter RS_DEPTH  = Cfg.RS_DEPTH,
+    parameter ALU_COUNT = Cfg.ALU_COUNT,
+    parameter RS_IDX_W = $clog2(RS_DEPTH)
+)(
+    input  wire [RS_DEPTH-1:0] ready_mask,
+
+    output logic [RS_DEPTH-1:0] issue_grant_mask,
+
+    output logic                  alu0_valid,
+    output logic [$clog2(RS_DEPTH)-1:0] alu0_rs_idx,
+    
+    output logic                  alu1_valid,
+    output logic [$clog2(RS_DEPTH)-1:0] alu1_rs_idx
+);
+
+    logic [RS_DEPTH-1:0] mask_stage_0;
+    logic [RS_DEPTH-1:0] mask_stage_1;
+    
+    logic [RS_DEPTH-1:0] grant_0;
+    logic [RS_DEPTH-1:0] grant_1;
+
+    function [RS_DEPTH-1:0] find_first_one;
+        input [RS_DEPTH-1:0] in_vec;
+        integer k;
+        reg found;
+    begin
+        find_first_one = 0;
+        found = 0;
+        for (k = 0; k < RS_DEPTH; k = k + 1) begin
+            if (in_vec[k] && !found) begin
+                find_first_one[k] = 1'b1;
+                found = 1'b1;
+            end
+        end
+    end
+    endfunction
+
+    
+    always_comb begin
+        mask_stage_0 = ready_mask;
+        grant_0      = find_first_one(mask_stage_0);
+
+        mask_stage_1 = mask_stage_0 & (~grant_0); 
+        grant_1      = find_first_one(mask_stage_1);
+
+        issue_grant_mask = grant_0 | grant_1;
+    end
+
+    integer i;
+    
+    always_comb begin
+        alu0_valid  = |grant_0;
+        alu0_rs_idx = 0;
+        for (i = 0; i < RS_DEPTH; i++) begin
+            if (grant_0[i]) alu0_rs_idx = i[$clog2(RS_DEPTH)-1:0];
+        end
+
+        alu1_valid  = |grant_1;
+        alu1_rs_idx = 0;
+        for (i = 0; i < RS_DEPTH; i++) begin
+            if (grant_1[i]) alu1_rs_idx = i[$clog2(RS_DEPTH)-1:0];
+        end
+    end
+
+endmodule

--- a/npc/vsrc/include/build_config_pkg.sv
+++ b/npc/vsrc/include/build_config_pkg.sv
@@ -27,6 +27,11 @@ package build_config_pkg;
     cfg.ICACHE_BANK_SEL_WIDTH = $clog2(cfg.ICACHE_NUM_BANKS);
     cfg.ICACHE_NUM_SETS = (user_cfg.ICACHE_BYTE_SIZE * 8) / user_cfg.ICACHE_SET_ASSOC / user_cfg.ICACHE_LINE_WIDTH;
 
+    // RS 配置
+    cfg.RS_DEPTH = user_cfg.RS_DEPTH;
+    
+    // ALU 配置
+    cfg.ALU_COUNT = user_cfg.ALU_COUNT;
     return cfg;
   endfunction
 endpackage

--- a/npc/vsrc/include/config_pkg.sv
+++ b/npc/vsrc/include/config_pkg.sv
@@ -28,6 +28,10 @@ package config_pkg;
     // Instruction cache line width
     int unsigned ICACHE_LINE_WIDTH;
 
+    int unsigned RS_DEPTH;
+
+    int unsigned ALU_COUNT;
+
   } user_cfg_t;
 
   typedef struct packed {
@@ -57,6 +61,12 @@ package config_pkg;
     int unsigned ICACHE_NUM_BANKS;
     int unsigned ICACHE_BANK_SEL_WIDTH;
     int unsigned ICACHE_NUM_SETS;
+    
+    // Reservation Station configuration
+    int unsigned RS_DEPTH;
+
+    // Execute Station configuration
+    int unsigned ALU_COUNT;
   } cfg_t;
   localparam cfg_t EmptyCfg = cfg_t'(0);
 endpackage

--- a/npc/vsrc/include/test_config_pkg.sv
+++ b/npc/vsrc/include/test_config_pkg.sv
@@ -8,6 +8,8 @@ package test_config_pkg;
       XLEN          : unsigned'(32),
       VLEN          : unsigned'(32),
       ILEN          : unsigned'(32),
+      RS_DEPTH     : unsigned'(16),
+      ALU_COUNT    : unsigned'(2),
       ICACHE_BYTE_SIZE : unsigned'(4096),
       ICACHE_SET_ASSOC : unsigned'(4),
       ICACHE_LINE_WIDTH : unsigned'(256)

--- a/npc/vsrc/test/tb_issue.sv
+++ b/npc/vsrc/test/tb_issue.sv
@@ -1,0 +1,84 @@
+import config_pkg::*;
+import build_config_pkg::*;
+
+module tb_issue #(
+    parameter config_pkg::cfg_t Cfg = global_config_pkg::Cfg,
+    parameter RS_DEPTH = Cfg.RS_DEPTH,
+    parameter DATA_W   = Cfg.ILEN,
+    parameter TAG_W    = 6
+)(
+    input wire clk,
+    input wire rst_n,
+
+    // Dispatch 通道
+    input wire [3:0]        dispatch_valid,
+    input wire [31:0]       dispatch_op     [0:3],
+    input wire [TAG_W-1:0]  dispatch_dst    [0:3],
+    // Src1
+    input wire [DATA_W-1:0] dispatch_v1     [0:3],
+    input wire [TAG_W-1:0]  dispatch_q1     [0:3],
+    input wire              dispatch_r1     [0:3],
+    // Src2
+    input wire [DATA_W-1:0] dispatch_v2     [0:3],
+    input wire [TAG_W-1:0]  dispatch_q2     [0:3],
+    input wire              dispatch_r2     [0:3],
+
+    output wire             issue_ready,
+
+    // CDB 通道
+    input wire [3:0]        cdb_valid,
+    input wire [TAG_W-1:0]  cdb_tag   [0:3],
+    input wire [DATA_W-1:0] cdb_val   [0:3],
+
+    // ALU 0 输出
+    output wire             alu0_en,
+    output wire [31:0]      alu0_op,
+    output wire [DATA_W-1:0] alu0_v1,
+    output wire [DATA_W-1:0] alu0_v2,
+    output wire [TAG_W-1:0]  alu0_dst,
+
+    // ALU 1 输出
+    output wire             alu1_en,
+    output wire [31:0]      alu1_op,
+    output wire [DATA_W-1:0] alu1_v1,
+    output wire [DATA_W-1:0] alu1_v2,
+    output wire [TAG_W-1:0]  alu1_dst
+);
+
+    // 实例化被测模块 (DUT)
+    issue #(
+        .Cfg(Cfg)
+    ) u_issue (
+        .clk            (clk),
+        .rst_n          (rst_n),
+
+        .dispatch_valid (dispatch_valid),
+        .dispatch_op    (dispatch_op),
+        .dispatch_dst   (dispatch_dst),
+        .dispatch_v1    (dispatch_v1),
+        .dispatch_q1    (dispatch_q1),
+        .dispatch_r1    (dispatch_r1),
+        .dispatch_v2    (dispatch_v2),
+        .dispatch_q2    (dispatch_q2),
+        .dispatch_r2    (dispatch_r2),
+
+        .issue_ready    (issue_ready),
+
+        .cdb_valid      (cdb_valid),
+        .cdb_tag        (cdb_tag),
+        .cdb_val        (cdb_val),
+
+        .alu0_en        (alu0_en),
+        .alu0_op        (alu0_op),
+        .alu0_v1        (alu0_v1),
+        .alu0_v2        (alu0_v2),
+        .alu0_dst       (alu0_dst),
+
+        .alu1_en        (alu1_en),
+        .alu1_op        (alu1_op),
+        .alu1_v1        (alu1_v1),
+        .alu1_v2        (alu1_v2),
+        .alu1_dst       (alu1_dst)
+    );
+
+endmodule


### PR DESCRIPTION
## Summary by Sourcery

实现一个可配置的乱序发射阶段，支持保留站以及相关测试。

New Features:
- 在全局配置和构建时配置中新增保留站深度和 ALU 数量的配置字段。
- 引入带保留站的发射阶段模块，包含分配和选择逻辑，根据就绪情况将指令派发到多个 ALU。
- 添加一个 SystemVerilog 测试平台以及一个基于 C++ Verilator 的测试程序，用于在就绪、依赖以及完全停顿等场景下验证新的发射阶段行为。

Bug Fixes:
- 调整分支预测单元测试的期望值，使其与正确的 next-PC 增量大小相匹配。

Tests:
- 扩展测试配置参数，在仿真中加入保留站深度和 ALU 数量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a configurable out-of-order issue stage with reservation station support and associated tests.

New Features:
- Add configuration fields for reservation station depth and ALU count to the global config and build-time configuration.
- Introduce an issue stage module with reservation station, allocation, and selection logic to dispatch instructions to multiple ALUs based on readiness.
- Add a SystemVerilog testbench and a C++ Verilator-based test program to verify the new issue stage behavior under readiness, dependency, and full-stall scenarios.

Bug Fixes:
- Adjust branch prediction unit test expectation to match the correct next-PC increment size.

Tests:
- Extend test configuration parameters to include reservation station depth and ALU count for simulation.

</details>