### PR TITLE
Execute

### DIFF
--- a/npc/vsrc/backend/execute.sv
+++ b/npc/vsrc/backend/execute.sv
@@ -1,0 +1,99 @@
+// vsrc/backend/execute_alu.sv
+import config_pkg::*;
+import decode_pkg::*;
+
+module execute_alu #(
+    parameter config_pkg::cfg_t Cfg = config_pkg::EmptyCfg // 假设 Cfg.XLEN = 32
+) (
+    input  logic                     clk_i,
+    input  logic                     rst_ni,
+
+    // 来自 Issue/Dispatch 阶段
+    input  logic                     alu_valid_i,
+    input  decode_pkg::uop_t         uop_i,
+    input  logic [31:0]              rs1_data_i,
+    input  logic [31:0]              rs2_data_i,
+
+    // 写回结果端口 (Writeback)
+    output logic                     alu_valid_o,
+    output logic [31:0]              alu_result_o,
+    output logic [4:0]               alu_rd_o,
+    output logic                     alu_rd_wen_o,
+    
+    // 控制流输出 (给 Branch Unit 或前端)
+    output logic [31:0]              alu_br_target_o,
+    output logic                     alu_br_take_o
+);
+
+  // --- 1. 操作数准备 ---
+  logic [31:0] op_a;
+  logic [31:0] op_b;
+
+  // Operand A 选择：通常是 rs1，但在 AUIPC 下是当前指令的 PC
+  assign op_a = (uop_i.alu_op == ALU_AUIPC) ? uop_i.pc : rs1_data_i;
+
+  // Operand B 选择：有 rs2 则选 rs2，否则选立即数（LUI/ADDI等）
+  // 注意：对于 Branch 指令，op_b 通常用于比较，而立即数用于算地址
+  assign op_b = (uop_i.has_rs2) ? rs2_data_i : uop_i.imm;
+
+  // --- 2. 算术与逻辑核心 ---
+  logic [31:0] alu_res;
+  
+  always_comb begin
+    alu_res = '0;
+    unique case (uop_i.alu_op)
+      ALU_ADD:   alu_res = op_a + op_b;
+      ALU_SUB:   alu_res = op_a - op_b;
+      ALU_LUI:   alu_res = uop_i.imm;
+      ALU_AUIPC: alu_res = op_a + op_b; // PC + Imm
+      
+      // 逻辑运算
+      ALU_AND:   alu_res = op_a & op_b;
+      ALU_OR:    alu_res = op_a | op_b;
+      ALU_XOR:   alu_res = op_a ^ op_b;
+
+      // 移位运算 (RV32I 移位量为 5 位)
+      ALU_SLL:   alu_res = op_a <<  op_b[4:0];
+      ALU_SRL:   alu_res = op_a >>  op_b[4:0];
+      ALU_SRA:   alu_res = $signed(op_a) >>> op_b[4:0];
+
+      // 比较运算 (SLT/SLTU)
+      ALU_SLT:   alu_res = ($signed(op_a) < $signed(op_b)) ? 32'b1 : 32'b0;
+      ALU_SLTU:  alu_res = (op_a < op_b) ? 32'b1 : 32'b0;
+
+      default:   alu_res = '0;
+    endcase
+  end
+
+  // --- 3. 跳转与分支处理 (Branch/Jump) ---
+  // 地址计算：JAL/Branch 使用 PC+Imm，JALR 使用 rs1+Imm
+  assign alu_br_target_o = (uop_i.br_op == BR_JALR) ? (rs1_data_i + uop_i.imm) : (uop_i.pc + uop_i.imm);
+
+  // 分支比较逻辑
+  always_comb begin
+    alu_br_take_o = 1'b0;
+    if (uop_i.is_branch) begin
+      unique case (uop_i.br_op)
+        BR_EQ:  alu_br_take_o = (rs1_data_i == rs2_data_i);
+        BR_NE:  alu_br_take_o = (rs1_data_i != rs2_data_i);
+        BR_LT:  alu_br_take_o = ($signed(rs1_data_i) <  $signed(rs2_data_i));
+        BR_GE:  alu_br_take_o = ($signed(rs1_data_i) >= $signed(rs2_data_i));
+        BR_LTU: alu_br_take_o = (rs1_data_i <  rs2_data_i);
+        BR_GEU: alu_br_take_o = (rs1_data_i >= rs2_data_i);
+        default: alu_br_take_o = 1'b0;
+      endcase
+    end else if (uop_i.is_jump) begin
+      alu_br_take_o = 1'b1; // JAL 和 JALR 总是跳转
+    end
+  end
+
+  // --- 4. 输出赋值 ---
+  assign alu_valid_o  = alu_valid_i && uop_i.valid;
+  
+  // 对于 Jump 指令，写回寄存器的数据通常是 PC + 4 (返回地址)
+  assign alu_result_o = (uop_i.is_jump) ? (uop_i.pc + 4) : alu_res;
+  
+  assign alu_rd_o     = uop_i.rd;
+  assign alu_rd_wen_o = uop_i.has_rd && alu_valid_o;
+
+endmodule

--- a/npc/vsrc/backend/issue/issue.sv
+++ b/npc/vsrc/backend/issue/issue.sv
@@ -1,3 +1,4 @@
+import decode_pkg::*;
 module issue #(
     parameter config_pkg::cfg_t Cfg = config_pkg::EmptyCfg,
     parameter RS_DEPTH = Cfg.RS_DEPTH,
@@ -7,9 +8,9 @@ module issue #(
     input wire clk,
     input wire rst_n,
 
-    input wire [3:0]        dispatch_valid,
-    input wire [31:0]       dispatch_op     [0:3],
-    input wire [TAG_W-1:0]  dispatch_dst    [0:3],
+    input wire [3:0]                        dispatch_valid,
+    input wire decode_pkg::uop_t            dispatch_op     [0:3],
+    input wire [TAG_W-1:0]                  dispatch_dst    [0:3],
     // Src1
     input wire [DATA_W-1:0] dispatch_v1     [0:3],
     input wire [TAG_W-1:0]  dispatch_q1     [0:3],
@@ -27,15 +28,15 @@ module issue #(
     input wire [DATA_W-1:0] cdb_val   [0:3],
 
     // ALU 0 接口
-    output wire             alu0_en,
-    output wire [31:0]      alu0_op,
+    output wire              alu0_en,
+    output decode_pkg::uop_t alu0_uop,
     output wire [DATA_W-1:0] alu0_v1,
     output wire [DATA_W-1:0] alu0_v2,
     output wire [TAG_W-1:0]  alu0_dst,
     
     // ALU 1 接口
-    output wire             alu1_en,
-    output wire [31:0]      alu1_op,
+    output wire              alu1_en,
+    output decode_pkg::uop_t alu1_uop,
     output wire [DATA_W-1:0] alu1_v1,
     output wire [DATA_W-1:0] alu1_v2,
     output wire [TAG_W-1:0]  alu1_dst
@@ -57,14 +58,14 @@ module issue #(
 
     // D. Crossbar <-> RS 输入数据线 (16组宽总线)
     // 这些是在 always_comb 里被驱动的
-    logic [31:0]       rs_in_op  [0:RS_DEPTH-1];
-    logic [TAG_W-1:0]  rs_in_dst [0:RS_DEPTH-1];
-    logic [DATA_W-1:0] rs_in_v1  [0:RS_DEPTH-1];
-    logic [TAG_W-1:0]  rs_in_q1  [0:RS_DEPTH-1];
-    logic              rs_in_r1  [0:RS_DEPTH-1];
-    logic [DATA_W-1:0] rs_in_v2  [0:RS_DEPTH-1];
-    logic [TAG_W-1:0]  rs_in_q2  [0:RS_DEPTH-1];
-    logic              rs_in_r2  [0:RS_DEPTH-1];
+    logic decode_pkg::uop_t     rs_in_op  [0:RS_DEPTH-1];
+    logic [TAG_W-1:0]           rs_in_dst [0:RS_DEPTH-1];
+    logic [DATA_W-1:0]          rs_in_v1  [0:RS_DEPTH-1];
+    logic [TAG_W-1:0]           rs_in_q1  [0:RS_DEPTH-1];
+    logic                       rs_in_r1  [0:RS_DEPTH-1];
+    logic [DATA_W-1:0]          rs_in_v2  [0:RS_DEPTH-1];
+    logic [TAG_W-1:0]           rs_in_q2  [0:RS_DEPTH-1];
+    logic                       rs_in_r2  [0:RS_DEPTH-1];
 
     // ==========================================
     // 模块 1: 分配器 (Allocator)

--- a/npc/vsrc/backend/issue/rs.sv
+++ b/npc/vsrc/backend/issue/rs.sv
@@ -11,7 +11,6 @@ module reservation_station #(
 
     input wire [RS_DEPTH-1:0]   entry_wen,
     
-    // 写端口 (来自 Crossbar)
     input wire [31:0]           in_op       [0:RS_DEPTH-1],
     input wire [TAG_W-1:0]      in_dst_tag  [0:RS_DEPTH-1],
     input wire [DATA_W-1:0]     in_v1       [0:RS_DEPTH-1],
@@ -21,7 +20,6 @@ module reservation_station #(
     input wire [TAG_W-1:0]      in_q2       [0:RS_DEPTH-1],
     input wire                  in_r2       [0:RS_DEPTH-1],
 
-    // CDB 监听
     input wire [CDB_W-1:0]      cdb_valid,
     input wire [TAG_W-1:0]      cdb_tag     [0:CDB_W-1],
     input wire [DATA_W-1:0]     cdb_value   [0:CDB_W-1],
@@ -49,7 +47,7 @@ module reservation_station #(
 
     // RS 存储阵列
     reg [RS_DEPTH-1:0]  busy;
-    reg [31:0]          op_arr  [0:RS_DEPTH-1];
+    reg decode_pkg::uop_t op_arr [0:RS_DEPTH-1];
     reg [TAG_W-1:0]     dst_arr [0:RS_DEPTH-1];
     
     reg [DATA_W-1:0]    v1_arr  [0:RS_DEPTH-1];

--- a/npc/vsrc/include/issue_pkg.sv
+++ b/npc/vsrc/include/issue_pkg.sv
@@ -1,0 +1,5 @@
+typedef struct packed {
+    logic        valid;
+    logic [5:0]  tag;
+    logic [31:0] data;
+} cdb_entry_t;


### PR DESCRIPTION
## Summary by Sourcery

将结构化微操作（micro-op）支持集成到指令发射（issue）和执行（execute）阶段，并引入一个专用的 ALU 执行模块。

新特性：
- 增加一个 `execute_alu` 模块，它基于解码后的微操作（micro-ops）执行整数 ALU、分支和跳转操作，并生成写回和控制流输出。
- 引入 `issue_pkg` 包，定义打包的 `cdb_entry_t` 类型，用于公共数据总线（Common Data Bus, CDB）条目。

改进：
- 优化发射端和保留站接口及存储结构，使其在传递时使用 `decode_pkg::uop_t` 微操作类型，而不是原始的 32 位操作字段，同时更新了 ALU 发射相关的输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate structured micro-op support into the issue and execute stages and introduce a dedicated ALU execute module.

New Features:
- Add an execute_alu module that performs integer ALU, branch, and jump operations based on decoded micro-ops and produces writeback and control-flow outputs.
- Introduce an issue_pkg package defining a packed cdb_entry_t type for common data bus entries.

Enhancements:
- Refine the issue and reservation station interfaces and storage to pass decode_pkg::uop_t micro-ops instead of raw 32-bit op fields, including updated ALU issue outputs.

</details>