### PR TITLE
[Feature] Add runtime flush/predict observability logs

### DIFF
--- a/npc/vsrc/test/tb_triathlon.sv
+++ b/npc/vsrc/test/tb_triathlon.sv
@@ -55,6 +55,13 @@ module tb_triathlon #(
     output logic [Cfg.XLEN-1:0]                dbg_csr_mcause_o,
     output logic                               backend_flush_o,
     output logic [Cfg.PLEN-1:0]                backend_redirect_pc_o,
+    output logic                               dbg_rob_flush_o,
+    output logic [4:0]                         dbg_rob_flush_cause_o,
+    output logic                               dbg_rob_flush_is_mispred_o,
+    output logic                               dbg_rob_flush_is_exception_o,
+    output logic                               dbg_rob_flush_is_branch_o,
+    output logic                               dbg_rob_flush_is_jump_o,
+    output logic [Cfg.PLEN-1:0]                dbg_rob_flush_src_pc_o,
 
     // Debug (frontend/backend handshakes)
     output logic                               dbg_fe_valid_o,
@@ -185,6 +192,13 @@ module tb_triathlon #(
   assign dbg_csr_mcause_o  = dut.u_backend.u_csr.csr_mcause;
   assign backend_flush_o = dut.u_backend.backend_flush_o;
   assign backend_redirect_pc_o = dut.u_backend.backend_redirect_pc_o;
+  assign dbg_rob_flush_o = dut.u_backend.rob_flush;
+  assign dbg_rob_flush_cause_o = dut.u_backend.rob_flush_cause;
+  assign dbg_rob_flush_is_mispred_o = dut.u_backend.rob_flush_is_mispred;
+  assign dbg_rob_flush_is_exception_o = dut.u_backend.rob_flush_is_exception;
+  assign dbg_rob_flush_is_branch_o = dut.u_backend.rob_flush_is_branch;
+  assign dbg_rob_flush_is_jump_o = dut.u_backend.rob_flush_is_jump;
+  assign dbg_rob_flush_src_pc_o = dut.u_backend.rob_flush_src_pc;
 
   // Debug: frontend/backend handshakes
   assign dbg_fe_valid_o = dut.fe_ibuf_valid;


### PR DESCRIPTION
## Summary by Sourcery

为后端刷新事件和分支预测行为添加详细的运行时可观测性，用于 NPC testbench 和模拟器。

New Features:
- 记录刷新事件的详细信息，包括：reason、source、cause、source PC、redirect PC、miss type、redirect distance，以及被清除的 micro-ops。
- 跟踪并报告分支和跳转预测统计数据，包括总数、未命中、命中以及 wrong-path work。
- 记录从一次刷新到下一次提交之间的 flush penalty cycles，用于性能分析。

Enhancements:
- 在 SystemVerilog testbench 中从 DUT 暴露 ROB 刷新调试信号，以支持更丰富的仿真端日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add detailed runtime observability for backend flush events and branch prediction behavior in the NPC testbench and simulator.

New Features:
- Log flush events with reason, source, cause, source PC, redirect PC, miss type, redirect distance, and killed micro-ops.
- Track and report branch and jump prediction statistics, including totals, misses, hits, and wrong-path work.
- Log flush penalty cycles between a flush and the next commit for performance analysis.

Enhancements:
- Expose ROB flush debug signals from the DUT in the SystemVerilog testbench for richer simulation-side logging.

</details>