### PR TITLE
[Tool] enhance profiler parsing and normalize noisy flush logs

### DIFF
--- a/npc/tools/profiler/parse_profile.py
+++ b/npc/tools/profiler/parse_profile.py
@@ -13,14 +13,96 @@ from typing import Any
 
 IPC_RE = re.compile(r"IPC=([0-9]+(?:\.[0-9]+)?)\s+CPI=([0-9]+(?:\.[0-9]+)?)\s+cycles=(\d+)\s+commits=(\d+)")
 TIMEOUT_RE = re.compile(r"TIMEOUT after (\d+) cycles")
-FLUSH_RE = re.compile(r"^\[flush \]\s+cycle=(\d+)")
+FLUSH_RE = re.compile(r"^\[flush \]\s+cycle=(\d+)(?:\s+reason=([a-zA-Z0-9_]+))?")
+FLUSHP_RE = re.compile(r"^\[flushp\]\s+cycle=(\d+)\s+reason=([a-zA-Z0-9_]+)\s+penalty=(\d+)")
 BRU_RE = re.compile(r"^\[bru\s+\]\s+cycle=(\d+)")
+PRED_RE = re.compile(
+    r"^\[pred\s+\]\s+cond_total=(\d+)\s+cond_miss=(\d+)(?:\s+cond_hit=(\d+))?\s+"
+    r"jump_total=(\d+)\s+jump_miss=(\d+)(?:\s+jump_hit=(\d+))?"
+)
 COMMIT_RE = re.compile(r"^\[commit\]\s+cycle=(\d+)\s+slot=(\d+)\s+pc=0x([0-9a-fA-F]+)\s+inst=0x([0-9a-fA-F]+)")
 STALL_RE = re.compile(r"^\[stall \]")
+KV_RE = re.compile(r"([a-zA-Z_][a-zA-Z0-9_]*)=([^\s]+)")
+
+FLUSH_REASON_ALLOWLIST = {"branch_mispredict", "exception", "rob_other", "external", "unknown"}
+FLUSH_SOURCE_ALLOWLIST = {"rob", "external", "unknown"}
+MISS_TYPE_ALLOWLIST = {"cond_branch", "jump", "control_unknown", "none"}
 
 
 def _safe_div(numer: float, denom: float) -> float:
     return 0.0 if denom == 0 else numer / denom
+
+
+def _parse_kv_pairs(line: str) -> dict[str, str]:
+    return {m.group(1): m.group(2) for m in KV_RE.finditer(line)}
+
+
+def _parse_int(token: str | None, default: int = 0) -> int:
+    if token is None:
+        return default
+    try:
+        return int(token, 0)
+    except ValueError:
+        return default
+
+
+def _compact_alpha(token: str) -> str:
+    return re.sub(r"[^a-z]", "", token.lower())
+
+
+def _normalize_flush_reason(token: str | None, line_ctx: str = "") -> str:
+    raw = "" if token is None else token.strip().lower()
+    if raw in FLUSH_REASON_ALLOWLIST:
+        return raw
+
+    compact = _compact_alpha(raw)
+    ctx = _compact_alpha(line_ctx)
+
+    if "except" in compact or "except" in ctx:
+        return "exception"
+    if "robother" in compact or "robother" in ctx:
+        return "rob_other"
+    if "extern" in compact or "extern" in ctx:
+        return "external"
+    if "unknown" in compact:
+        return "unknown"
+    if ("misp" in compact or "mispr" in compact or "misp" in ctx or "mispr" in ctx) and (
+        "branch" in compact or "ranch" in compact or "branch" in ctx or "ranch" in ctx
+    ):
+        return "branch_mispredict"
+    return "unknown"
+
+
+def _normalize_flush_source(token: str | None) -> str:
+    raw = "" if token is None else token.strip().lower()
+    if raw in FLUSH_SOURCE_ALLOWLIST:
+        return raw
+
+    compact = _compact_alpha(raw)
+    if "rob" in compact:
+        return "rob"
+    if "extern" in compact:
+        return "external"
+    if "unknown" in compact:
+        return "unknown"
+    return "unknown"
+
+
+def _normalize_miss_type(token: str | None) -> str:
+    raw = "" if token is None else token.strip().lower()
+    if raw in MISS_TYPE_ALLOWLIST:
+        return raw
+
+    compact = _compact_alpha(raw)
+    if "jump" in compact or compact.startswith("jal"):
+        return "jump"
+    if "control" in compact:
+        return "control_unknown"
+    if "none" in compact:
+        return "none"
+    if "cond" in compact and "branch" in compact:
+        return "cond_branch"
+    return "none"
 
 
 def _classify_stall(line: str) -> str:
@@ -116,6 +198,21 @@ def parse_single_log(path: str | Path) -> dict[str, Any]:
 
     flush_count = 0
     bru_count = 0
+    mispredict_flush_count = 0
+    mispredict_cond_count = 0
+    mispredict_jump_count = 0
+    branch_penalty_cycles = 0
+    wrong_path_kill_uops = 0
+    redirect_distance_sum = 0
+    redirect_distance_samples = 0
+    redirect_distance_max = 0
+    flush_reason_hist: Counter[str] = Counter()
+    flush_source_hist: Counter[str] = Counter()
+
+    pred_cond_total_line: int | None = None
+    pred_cond_miss_line: int | None = None
+    pred_jump_total_line: int | None = None
+    pred_jump_miss_line: int | None = None
 
     commit_by_cycle: dict[int, int] = defaultdict(int)
     commit_seq: list[tuple[int, int, int, int]] = []
@@ -138,12 +235,63 @@ def parse_single_log(path: str | Path) -> dict[str, Any]:
             timeout_cycles = int(m.group(1))
             continue
 
-        if FLUSH_RE.match(raw):
+        flush_pos = raw.find("[flush ]")
+        if flush_pos >= 0:
+            flush_line = raw[flush_pos:]
             flush_count += 1
+            kv = _parse_kv_pairs(flush_line)
+            reason_raw = kv.get("reason", "unknown")
+            source_raw = kv.get("source", "unknown")
+            miss_type_raw = kv.get("miss_type", "none")
+            redirect_distance = _parse_int(kv.get("redirect_distance"), 0)
+            killed_uops = _parse_int(kv.get("killed_uops"), 0)
+
+            # Backward compatibility for old log format: [flush ] cycle=... reason=...
+            if reason_raw == "unknown":
+                m = FLUSH_RE.match(flush_line)
+                if m and m.group(2):
+                    reason_raw = m.group(2)
+
+            reason = _normalize_flush_reason(reason_raw, flush_line)
+            source = _normalize_flush_source(source_raw)
+            miss_type = _normalize_miss_type(miss_type_raw)
+
+            flush_reason_hist[reason] += 1
+            flush_source_hist[source] += 1
+            redirect_distance_sum += redirect_distance
+            redirect_distance_samples += 1
+            redirect_distance_max = max(redirect_distance_max, redirect_distance)
+
+            if reason == "branch_mispredict":
+                mispredict_flush_count += 1
+                wrong_path_kill_uops += killed_uops
+                if miss_type == "cond_branch":
+                    mispredict_cond_count += 1
+                elif miss_type == "jump":
+                    mispredict_jump_count += 1
+            continue
+
+        flushp_pos = raw.find("[flushp]")
+        if flushp_pos >= 0:
+            m = FLUSHP_RE.match(raw[flushp_pos:])
+            if not m:
+                continue
+            reason = _normalize_flush_reason(m.group(2), raw[flushp_pos:])
+            penalty = int(m.group(3))
+            if reason == "branch_mispredict":
+                branch_penalty_cycles += penalty
             continue
 
         if BRU_RE.match(raw):
             bru_count += 1
+            continue
+
+        m = PRED_RE.match(raw)
+        if m:
+            pred_cond_total_line = int(m.group(1))
+            pred_cond_miss_line = int(m.group(2))
+            pred_jump_total_line = int(m.group(4))
+            pred_jump_miss_line = int(m.group(5))
             continue
 
         m = COMMIT_RE.match(raw)
@@ -163,6 +311,31 @@ def parse_single_log(path: str | Path) -> dict[str, Any]:
 
     commit_width_hist = _commit_histogram(cycles, commit_by_cycle)
     control = _control_flow_metrics(commit_seq)
+
+    cond_total = int(control.get("branch_count", 0))
+    jump_total = int(control.get("jal_count", 0)) + int(control.get("jalr_count", 0))
+    cond_miss = mispredict_cond_count
+    jump_miss = mispredict_jump_count
+    if pred_cond_total_line is not None:
+        cond_total = pred_cond_total_line
+    if pred_cond_miss_line is not None:
+        cond_miss = pred_cond_miss_line
+    if pred_jump_total_line is not None:
+        jump_total = pred_jump_total_line
+    if pred_jump_miss_line is not None:
+        jump_miss = pred_jump_miss_line
+    cond_hit = max(0, cond_total - cond_miss)
+    jump_hit = max(0, jump_total - jump_miss)
+    predict = {
+        "cond_total": cond_total,
+        "cond_miss": cond_miss,
+        "cond_hit": cond_hit,
+        "cond_miss_rate": _safe_div(cond_miss, cond_total),
+        "jump_total": jump_total,
+        "jump_miss": jump_miss,
+        "jump_hit": jump_hit,
+        "jump_miss_rate": _safe_div(jump_miss, jump_total),
+    }
 
     # Fallback path for timeout/sample logs without final IPC line.
     if cycles == 0 and timeout_cycles > 0:
@@ -185,6 +358,15 @@ def parse_single_log(path: str | Path) -> dict[str, Any]:
         "commits": commits,
         "flush_count": flush_count,
         "bru_count": bru_count,
+        "mispredict_flush_count": mispredict_flush_count,
+        "branch_penalty_cycles": branch_penalty_cycles,
+        "wrong_path_kill_uops": wrong_path_kill_uops,
+        "redirect_distance_sum": redirect_distance_sum,
+        "redirect_distance_samples": redirect_distance_samples,
+        "redirect_distance_avg": _safe_div(redirect_distance_sum, redirect_distance_samples),
+        "redirect_distance_max": redirect_distance_max,
+        "flush_reason_histogram": dict(flush_reason_hist),
+        "flush_source_histogram": dict(flush_source_hist),
         "flush_per_kinst": 1000.0 * _safe_div(flush_count, commits),
         "bru_per_kinst": 1000.0 * _safe_div(bru_count, commits),
         "commit_width_hist": commit_width_hist,
@@ -193,6 +375,7 @@ def parse_single_log(path: str | Path) -> dict[str, Any]:
         "top_pc": [{"pc": f"0x{pc:08x}", "count": cnt} for pc, cnt in hotspot_pc.most_common(10)],
         "top_inst": [{"inst": f"0x{inst:08x}", "count": cnt} for inst, cnt in hotspot_inst.most_common(10)],
         "control": control,
+        "predict": predict,
     }
 
 
@@ -229,6 +412,9 @@ def _bench_markdown(name: str, data: dict[str, Any]) -> str:
     stall = data.get("stall_category", {})
     stall_total = data.get("stall_total", 0)
     control = data.get("control", {})
+    flush_hist = data.get("flush_reason_histogram", {})
+    flush_src_hist = data.get("flush_source_histogram", {})
+    predict = data.get("predict", {})
 
     lines = [
         f"### {name}",
@@ -237,8 +423,14 @@ def _bench_markdown(name: str, data: dict[str, Any]) -> str:
         f"- cycles/commits: `{data.get('cycles', 0)}` / `{data.get('commits', 0)}`",
         f"- flush_per_kinst: `{data.get('flush_per_kinst', 0):.3f}`",
         f"- bru_per_kinst: `{data.get('bru_per_kinst', 0):.3f}`",
+        f"- mispredict_flush_count: `{data.get('mispredict_flush_count', 0)}`",
+        f"- branch_penalty_cycles: `{data.get('branch_penalty_cycles', 0)}`",
+        f"- wrong_path_kill_uops: `{data.get('wrong_path_kill_uops', 0)}`",
+        f"- redirect_distance_avg/max: `{data.get('redirect_distance_avg', 0):.2f}` / `{data.get('redirect_distance_max', 0)}`",
         f"- control_ratio: `{control.get('control_ratio', 0) * 100.0:.2f}%`",
         f"- est_misp_per_kinst(static NT proxy): `{control.get('est_misp_per_kinst', 0):.3f}`",
+        f"- predict(cond hit/miss): `{predict.get('cond_hit', 0)}` / `{predict.get('cond_miss', 0)}` (miss_rate `{predict.get('cond_miss_rate', 0) * 100.0:.2f}%`)",
+        f"- predict(jump hit/miss): `{predict.get('jump_hit', 0)}` / `{predict.get('jump_miss', 0)}` (miss_rate `{predict.get('jump_miss_rate', 0) * 100.0:.2f}%`)",
         "",
         "Commit Width Histogram:",
         f"- width0: `{hist.get(0, 0)}`",
@@ -255,6 +447,22 @@ def _bench_markdown(name: str, data: dict[str, Any]) -> str:
     else:
         for key, val in sorted(stall.items(), key=lambda x: x[1], reverse=True):
             lines.append(f"- {key}: `{val}` ({_fmt_pct(val, stall_total)})")
+
+    lines.append("")
+    lines.append("Flush Reasons:")
+    if flush_hist:
+        for key, val in sorted(flush_hist.items(), key=lambda x: x[1], reverse=True):
+            lines.append(f"- {key}: `{val}`")
+    else:
+        lines.append("- (no flush samples)")
+
+    lines.append("")
+    lines.append("Flush Sources:")
+    if flush_src_hist:
+        for key, val in sorted(flush_src_hist.items(), key=lambda x: x[1], reverse=True):
+            lines.append(f"- {key}: `{val}`")
+    else:
+        lines.append("- (no flush samples)")
 
     if data.get("top_pc"):
         lines.extend(["", "Top PC Hotspots:"])

--- a/npc/tools/profiler/report_template.md
+++ b/npc/tools/profiler/report_template.md
@@ -6,3 +6,10 @@
 ## Benchmark Summary
 
 {{BENCHMARK_SECTIONS}}
+
+## Notes
+
+- `mispredict_flush_count` 和 `branch_penalty_cycles` 来自运行时 `flush/flushp` 事件日志。
+- `flush_reason_histogram` 与 `flush_source_histogram` 用于区分 flush 根因及来源（ROB/外部）。
+- `predict` 统计来自运行时 `[pred]` 汇总日志，按 `cond_branch/jump` 给出 hit/miss。
+- `wrong_path_kill_uops` 与 `redirect_distance_*` 来自 flush 事件字段，用于估计错误路径清除开销。


### PR DESCRIPTION
## Summary by Sourcery

增强 profiler 日志解析器和报告功能，以提取更丰富的分支预测和冲刷流水诊断信息，同时对嘈杂的 flush 日志进行规范化处理。

新功能：
- 解析扩展的 `[flush]`、`[flushp]` 和 `[pred]` 日志格式，以计算更详细的分支错误预测和预测统计数据。
- 在解析结果和 Markdown 报告中公开条件分支和跳转的预测指标（命中、未命中、未命中率）。
- 从 flush 事件中跟踪重定向距离和错误路径 uops，以估算错误预测恢复成本。
- 将 flush 原因和来源汇总为直方图，以纳入基准测试摘要和报告中。

错误修复：
- 将嘈杂或格式错误的 flush 日志行规范化为受限的原因和来源类别集合，以防止在摘要中出现虚假值。

增强：
- 扩展 Markdown 基准测试报告，增加错误预测计数、惩罚、flush 直方图和预测统计等新字段。
- 通过在提取原因时支持旧版 flush 日志格式来提高向后兼容性。

文档：
- 在报告模板的说明部分记录新的 profiler 指标及其来源。

测试：
- 添加并更新 profiler 解析测试，以覆盖新的 flush/pred 格式、错误预测指标以及对嘈杂 flush 行的规范化处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the profiler log parser and reports to extract richer branch prediction and flush diagnostics while normalizing noisy flush logs.

New Features:
- Parse extended [flush], [flushp], and [pred] log formats to compute detailed branch misprediction and prediction statistics.
- Expose prediction metrics (hits, misses, miss rates) for conditional branches and jumps in the parsed output and markdown reports.
- Track redirect distance and wrong-path uops from flush events to estimate misprediction recovery cost.
- Aggregate flush reasons and sources into histograms for inclusion in benchmark summaries and reports.

Bug Fixes:
- Normalize noisy or malformed flush log lines into a constrained set of reason and source categories to prevent spurious values in summaries.

Enhancements:
- Extend markdown benchmark reports with new fields for misprediction counts, penalties, flush histograms, and prediction stats.
- Improve backward compatibility by supporting legacy flush log formats when extracting reasons.

Documentation:
- Document the new profiler metrics and their origins in the report template notes section.

Tests:
- Add and update profiler parsing tests to cover new flush/pred formats, misprediction metrics, and normalization of noisy flush lines.

</details>