### PR TITLE
[Feature] Land control-flow observability and RAS scaffolding

### DIFF
--- a/npc/csrc/test_frontend.cpp
+++ b/npc/csrc/test_frontend.cpp
@@ -143,6 +143,8 @@ int main(int argc, char **argv) {
   top->bpu_update_is_cond_i = 0;
   top->bpu_update_taken_i = 0;
   top->bpu_update_target_i = 0;
+  top->bpu_update_is_call_i = 0;
+  top->bpu_update_is_ret_i = 0;
   for (int i = 0; i < 5; i++)
     tick(top, mem);
   top->rst_ni = 1;

--- a/npc/tools/profiler/report_template.md
+++ b/npc/tools/profiler/report_template.md
@@ -11,5 +11,5 @@
 
 - `mispredict_flush_count` 和 `branch_penalty_cycles` 来自运行时 `flush/flushp` 事件日志。
 - `flush_reason_histogram` 与 `flush_source_histogram` 用于区分 flush 根因及来源（ROB/外部）。
-- `predict` 统计来自运行时 `[pred]` 汇总日志，按 `cond_branch/jump` 给出 hit/miss。
+- `predict` 统计来自运行时 `[pred]` 汇总日志，按 `cond_branch/jump/return` 给出 hit/miss，并提供 `call_total`。
 - `wrong_path_kill_uops` 与 `redirect_distance_*` 来自 flush 事件字段，用于估计错误路径清除开销。

--- a/npc/vsrc/backend/rename/rename.sv
+++ b/npc/vsrc/backend/rename/rename.sv
@@ -25,6 +25,8 @@ module rename #(
     output logic            [3:0]               rob_dispatch_has_rd_o,
     output logic            [3:0]               rob_dispatch_is_branch_o,
     output logic            [3:0]               rob_dispatch_is_jump_o,
+    output logic            [3:0]               rob_dispatch_is_call_o,
+    output logic            [3:0]               rob_dispatch_is_ret_o,
 
     // [新增] 傳遞 Store 信息給 ROB
     output logic [3:0]                   rob_dispatch_is_store_o,
@@ -196,6 +198,12 @@ module rename #(
         rob_dispatch_has_rd_o[i]   = dec_uops_i[i].has_rd;
         rob_dispatch_is_branch_o[i] = dec_uops_i[i].is_branch;
         rob_dispatch_is_jump_o[i] = dec_uops_i[i].is_jump;
+        rob_dispatch_is_call_o[i] = dec_uops_i[i].is_jump &&
+            ((dec_uops_i[i].rd == 5'd1) || (dec_uops_i[i].rd == 5'd5));
+        rob_dispatch_is_ret_o[i] = (dec_uops_i[i].br_op == decode_pkg::BR_JALR) &&
+            (dec_uops_i[i].rd == 5'd0) &&
+            ((dec_uops_i[i].rs1 == 5'd1) || (dec_uops_i[i].rs1 == 5'd5)) &&
+            (dec_uops_i[i].imm == Cfg.XLEN'(0));
 
         // Store 信息傳遞
         rob_dispatch_is_store_o[i] = dec_uops_i[i].is_store;
@@ -231,6 +239,8 @@ module rename #(
         rob_dispatch_has_rd_o[i]   = 1'b0;
         rob_dispatch_is_branch_o[i] = 1'b0;
         rob_dispatch_is_jump_o[i] = 1'b0;
+        rob_dispatch_is_call_o[i] = 1'b0;
+        rob_dispatch_is_ret_o[i] = 1'b0;
         rob_dispatch_is_store_o[i] = 1'b0;
         rob_dispatch_sb_id_o[i]    = '0;
 

--- a/npc/vsrc/backend/retire/rob.sv
+++ b/npc/vsrc/backend/retire/rob.sv
@@ -26,6 +26,8 @@ module rob #(
     input logic            [DISPATCH_WIDTH-1:0]               dispatch_has_rd_i,
     input logic            [DISPATCH_WIDTH-1:0]               dispatch_is_branch_i,
     input logic            [DISPATCH_WIDTH-1:0]               dispatch_is_jump_i,
+    input logic            [DISPATCH_WIDTH-1:0]               dispatch_is_call_i,
+    input logic            [DISPATCH_WIDTH-1:0]               dispatch_is_ret_i,
 
     // [新增] 接收 Store Buffer ID
     // 只有当指令是 Store 时，这个信号才有效；否则忽略
@@ -67,6 +69,8 @@ module rob #(
     output logic [COMMIT_WIDTH-1:0][SB_IDX_WIDTH-1:0] commit_sb_id_o,
     output logic [COMMIT_WIDTH-1:0]                    commit_is_branch_o,
     output logic [COMMIT_WIDTH-1:0]                    commit_is_jump_o,
+    output logic [COMMIT_WIDTH-1:0]                    commit_is_call_o,
+    output logic [COMMIT_WIDTH-1:0]                    commit_is_ret_o,
     output logic [COMMIT_WIDTH-1:0][Cfg.PLEN-1:0]      commit_actual_npc_o,
 
     // Flush Interface
@@ -108,6 +112,8 @@ module rob #(
     logic has_rd;
     logic is_branch;
     logic is_jump;
+    logic is_call;
+    logic is_ret;
     logic [Cfg.XLEN-1:0] data;
     logic [Cfg.PLEN-1:0] pc;
 
@@ -163,6 +169,8 @@ module rob #(
     commit_sb_id_o    = '0; // 默认清零
     commit_is_branch_o = '0;
     commit_is_jump_o = '0;
+    commit_is_call_o = '0;
+    commit_is_ret_o = '0;
     commit_actual_npc_o = '0;
     commit_rob_index_o = '0;
 
@@ -226,6 +234,8 @@ module rob #(
             commit_sb_id_o[i]    = rob_ram[idx].sb_id;
             commit_is_branch_o[i] = rob_ram[idx].is_branch;
             commit_is_jump_o[i] = rob_ram[idx].is_jump;
+            commit_is_call_o[i] = rob_ram[idx].is_call;
+            commit_is_ret_o[i] = rob_ram[idx].is_ret;
             commit_actual_npc_o[i] = rob_ram[idx].redirect_pc;
 
             stop_commit          = 1'b1;
@@ -251,6 +261,8 @@ module rob #(
             commit_sb_id_o[i]    = rob_ram[idx].sb_id;
             commit_is_branch_o[i] = rob_ram[idx].is_branch;
             commit_is_jump_o[i] = rob_ram[idx].is_jump;
+            commit_is_call_o[i] = rob_ram[idx].is_call;
+            commit_is_ret_o[i] = rob_ram[idx].is_ret;
             commit_actual_npc_o[i] = rob_ram[idx].redirect_pc;
           end
         end else begin
@@ -325,6 +337,8 @@ module rob #(
             rob_ram[w_idx].has_rd      <= dispatch_has_rd_i[i];
             rob_ram[w_idx].is_branch   <= dispatch_is_branch_i[i];
             rob_ram[w_idx].is_jump     <= dispatch_is_jump_i[i];
+            rob_ram[w_idx].is_call     <= dispatch_is_call_i[i];
+            rob_ram[w_idx].is_ret      <= dispatch_is_ret_i[i];
             rob_ram[w_idx].pc          <= dispatch_pc_i[i];
 
             // [新增] 保存 SB ID

--- a/npc/vsrc/frontend/frontend.sv
+++ b/npc/vsrc/frontend/frontend.sv
@@ -26,6 +26,8 @@ module frontend #(
     input logic                bpu_update_is_cond_i,
     input logic                bpu_update_taken_i,
     input logic [Cfg.PLEN-1:0] bpu_update_target_i,
+    input logic                bpu_update_is_call_i,
+    input logic                bpu_update_is_ret_i,
 
     // ============================================
     // 2. 存储器系统接口 (To Memory/L2/Bus)
@@ -140,6 +142,8 @@ module frontend #(
       .update_is_cond_i      (bpu_update_is_cond_i),
       .update_taken_i        (bpu_update_taken_i),
       .update_target_i       (bpu_update_target_i),
+      .update_is_call_i      (bpu_update_is_call_i),
+      .update_is_ret_i       (bpu_update_is_ret_i),
       .bpu_to_ifu_handshake_o(bpu2ifu_handshake),
       .bpu_to_ifu_o          (bpu_to_ifu_struct)
   );

--- a/npc/vsrc/test/tb_backend.sv
+++ b/npc/vsrc/test/tb_backend.sv
@@ -44,6 +44,8 @@ module tb_backend (
     output logic                               bpu_update_is_cond_o,
     output logic                               bpu_update_taken_o,
     output logic [Cfg.PLEN-1:0]                bpu_update_target_o,
+    output logic                               bpu_update_is_call_o,
+    output logic                               bpu_update_is_ret_o,
     output logic                               rob_flush_o,
     output logic [Cfg.PLEN-1:0]                rob_flush_pc_o
 );
@@ -70,6 +72,8 @@ module tb_backend (
       .bpu_update_is_cond_o(bpu_update_is_cond_o),
       .bpu_update_taken_o(bpu_update_taken_o),
       .bpu_update_target_o(bpu_update_target_o),
+      .bpu_update_is_call_o(bpu_update_is_call_o),
+      .bpu_update_is_ret_o(bpu_update_is_ret_o),
 
       .dcache_miss_req_valid_o,
       .dcache_miss_req_ready_i,

--- a/npc/vsrc/test/tb_bpu.sv
+++ b/npc/vsrc/test/tb_bpu.sv
@@ -14,6 +14,8 @@ module tb_bpu (
     input logic update_is_cond_i,
     input logic update_taken_i,
     input logic [Cfg.XLEN-1:0] update_target_i,
+    input logic update_is_call_i,
+    input logic update_is_ret_i,
     // --- 输出端口  ---
     output logic [Cfg.XLEN-1:0] npc_o,
     output logic pred_slot_valid_o,
@@ -39,6 +41,8 @@ module tb_bpu (
       .update_is_cond_i(update_is_cond_i),
       .update_taken_i(update_taken_i),
       .update_target_i(update_target_i),
+      .update_is_call_i(update_is_call_i),
+      .update_is_ret_i(update_is_ret_i),
 
       .bpu_to_ifu_handshake_o(bpu_to_ifu_handshake_o),
       .bpu_to_ifu_o(bpu_to_ifu_o)

--- a/npc/vsrc/test/tb_frontend.sv
+++ b/npc/vsrc/test/tb_frontend.sv
@@ -24,6 +24,8 @@ module tb_frontend (
     input logic                bpu_update_is_cond_i,
     input logic                bpu_update_taken_i,
     input logic [Cfg.PLEN-1:0] bpu_update_target_i,
+    input logic                bpu_update_is_call_i,
+    input logic                bpu_update_is_ret_i,
 
     // ============================================
     // 2. 存储器系统接口 (To Memory/L2/Bus)
@@ -65,6 +67,8 @@ module tb_frontend (
       .bpu_update_is_cond_i(bpu_update_is_cond_i),
       .bpu_update_taken_i(bpu_update_taken_i),
       .bpu_update_target_i(bpu_update_target_i),
+      .bpu_update_is_call_i(bpu_update_is_call_i),
+      .bpu_update_is_ret_i(bpu_update_is_ret_i),
 
       .miss_req_valid_o     (miss_req_valid_o),
       .miss_req_ready_i     (miss_req_ready_i),

--- a/npc/vsrc/triathlon.sv
+++ b/npc/vsrc/triathlon.sv
@@ -62,6 +62,8 @@ module triathlon #(
   logic bpu_update_is_cond;
   logic bpu_update_taken;
   logic [Cfg.PLEN-1:0] bpu_update_target;
+  logic bpu_update_is_call;
+  logic bpu_update_is_ret;
 
   frontend #(
       .Cfg(Cfg)
@@ -83,6 +85,8 @@ module triathlon #(
       .bpu_update_is_cond_i(bpu_update_is_cond),
       .bpu_update_taken_i(bpu_update_taken),
       .bpu_update_target_i(bpu_update_target),
+      .bpu_update_is_call_i(bpu_update_is_call),
+      .bpu_update_is_ret_i(bpu_update_is_ret),
 
       .miss_req_valid_o     (icache_miss_req_valid_o),
       .miss_req_ready_i     (icache_miss_req_ready_i),
@@ -121,6 +125,8 @@ module triathlon #(
       .bpu_update_is_cond_o(bpu_update_is_cond),
       .bpu_update_taken_o(bpu_update_taken),
       .bpu_update_target_o(bpu_update_target),
+      .bpu_update_is_call_o(bpu_update_is_call),
+      .bpu_update_is_ret_o(bpu_update_is_ret),
 
       .dcache_miss_req_valid_o(dcache_miss_req_valid_o),
       .dcache_miss_req_ready_i(dcache_miss_req_ready_i),


### PR DESCRIPTION
Dhrystone IPC=0.562253
CoreMark IPC=0.623872

## Summary by Sourcery

在核心、预测器和性能分析中添加对调用/返回感知的控制流可观测性，并在分支预测器中引入返回地址栈。

New Features:
- 在 rename/ROB/backend 中添加调用/返回分类，并将 call/ret 元数据传播到 BPU 更新接口。
- 在 BPU 中引入返回地址栈以改进返回预测，并将其与 BTB 条目和预测流程集成。
- 扩展运行时日志和分析器，以跟踪调用/返回预测统计和误预测分布，包括新的返回相关指标。

Enhancements:
- 在刷新日志中通过区分包括返回在内的 miss_subtype 值，细化缺失类型处理，以便进行更细粒度的分析。
- 改进 backend 和 frontend 模块中的代码格式与信号命名一致性，以提高可读性。

Documentation:
- 更新分析器报告模板，以记录扩展后的控制流预测指标，包括调用和返回统计。

Tests:
- 扩展 BPU 和 frontend 的测试平台，以覆盖新的调用/返回更新信号和 RAS 行为，包括嵌套和陈旧 RAS 场景。
- 添加分析器测试，用于验证对新的预测和返回相关 flush subtype 指标的解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add call/return-aware control-flow observability across core, predictor, and profiling, and introduce a return-address stack in the branch predictor.

New Features:
- Add call/return classification in rename/ROB/backend and propagate call/ret metadata to the BPU update interface.
- Introduce a return-address stack in the BPU to improve return prediction and integrate it with BTB entries and prediction flow.
- Extend runtime logging and the profiler to track call/return prediction statistics and mispredict breakdowns, including new return-specific metrics.

Enhancements:
- Refine miss-type handling in flush logs by distinguishing miss_subtype values including returns for finer-grained analysis.
- Improve code formatting and signal naming consistency in backend and frontend modules for readability.

Documentation:
- Update the profiler report template to document the extended control-flow prediction metrics, including return and call statistics.

Tests:
- Extend BPU and frontend testbenches to cover the new call/return update signals and RAS behavior, including nested and stale-RAS scenarios.
- Add profiler tests to validate parsing of the new prediction and flush subtype metrics for returns.

</details>